### PR TITLE
Add missing backslash case for read_punct

### DIFF
--- a/tokenize.c
+++ b/tokenize.c
@@ -204,6 +204,7 @@ static int read_punct(const char *p) {
   case '{':
   case '}':
   case '~':
+  case '\\':
     return 1;
   }
   return 0;


### PR DESCRIPTION
This was mentioned by fuhsnn, which was originally handled by `ispunct(char)` in the return at the end of function body.